### PR TITLE
Don't attempt to assign to a null GetOpt.parameters

### DIFF
--- a/GetOpt_Update.cs
+++ b/GetOpt_Update.cs
@@ -203,7 +203,10 @@ namespace NMaier.GetOptNet
             break;
           }
         }
-
+        if (parameters == null)
+        {
+          throw new GetOptException(string.Format("Unamed paramater value \"{0}\" not found.", c));
+        }
         UpdateHandler(parameters, c, "<parameters>");
       }
 


### PR DESCRIPTION
If I don't set a MultipleArgumentHandler, and the user types in something like `-file foo` instead of `--file foo`, a `ProgrammingError` will be thrown.